### PR TITLE
Update Gameplay.MaterialInstance.md

### DIFF
--- a/docs/classes/Gameplay.MaterialInstance.md
+++ b/docs/classes/Gameplay.MaterialInstance.md
@@ -176,3 +176,16 @@ ___
 | `parameterName` | `string` |  参数名称 |
 | `value` | [`LinearColor`](Type.LinearColor.md) |  参数值 |
 
+```ts
+// 从023开始,我们设置材质的颜色,是这么处理的
+// 1. 先通过guid获取到需要改颜色的游戏物体
+Gameplay.GameObject.asyncFind("需改颜色模型的guid").then(go => {
+    // 2. 将go的“游戏物体”类型 转换为 “静态模型”类型 后，赋值给sm
+    let sm = go as Gameplay.StaticMesh
+    // 3. 获取到sm的材质示例
+    // getMaterialInstance()[0]这里我是去获取对象的第一个材质实例
+    // 4. MWMainColor是设置主颜色相关的参数名
+    // new Type.LinearColor(1, 0, 0)，r=1,g=0,b=0 为正红色  
+    sm.getMaterialInstance()[0].setVectorParameterValue("MW_MlainColor", new Type.LinearColor(1, 0, 0))
+})
+```


### PR DESCRIPTION
补充setVectorParameterValue(parameterName, value): void设置颜色参数值的用法示例 -------------------------------------------------------------------------------------------- 另外有个疑惑点请教一下~目前 setVectorParameterValue(parameterName, value) 这个接口叫"修改颜色",value也只有一个LinearColor类型 为什么接口名是 setVector "设置向量" ?而不是 setxxx color "设置颜色" 之类的。。。 还是说后续这个接口可以修改不止颜色一个类型吗?
那是否应该考虑一下：
1. 将接口解释为"修改参数值(目前支持颜色)",在value这一栏的type加更多解释呢?
2. 如果是这个接口只能改颜色,当初为什么要用Vector命名呢? 希望api文档的一些改动, 容易引起歧义的地方 可以多一些解释, 拜托啦!!!