### PR TITLE
Update mw.Animation.md to delete Animation constructor

### DIFF
--- a/docs/classes/mw.Animation.md
+++ b/docs/classes/mw.Animation.md
@@ -34,8 +34,7 @@
 ## Table of contents
 
 ### Constructors <Score text="Constructors" /> 
-| **new Animation**()  |
-| :----- |
+
 
 ### Accessors <Score text="Accessors" /> 
 | **[assetId](mw.Animation.md#assetid)**(): `string`  |


### PR DESCRIPTION
Animation无法通过TS的new关键字来实例化，所以不应该在文档里写构造函数

there is no way instance Animation class by keyword 'new' in TypeScript. so we should not add constructor function in this document